### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,19 +6,19 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-RingBuffer				    KEYWORD1
+RingBuffer	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-push	  							KEYWORD2
-pop										KEYWORD2
-isFull								KEYWORD2
-isEmpty								KEYWORD2
-clear									KEYWORD2
-lockedPush						KEYWORD2
-lockedPop							KEYWORD2
+push	KEYWORD2
+pop	KEYWORD2
+isFull	KEYWORD2
+isEmpty	KEYWORD2
+clear	KEYWORD2
+lockedPush	KEYWORD2
+lockedPop	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style highlighting  to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special highlighting.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords